### PR TITLE
Fix: Changes pandas version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ celerybeat-schedule
 .venv
 venv/
 ENV/
+egcenv/
 
 # Spyder project settings
 .spyderproject

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ django-rest-swagger==2.2.0
 selenium==4.7.2
 pynose==1.4.8
 reportlab==3.6.1
-pandas==2.1.4
+pandas==2.0.3


### PR DESCRIPTION
This commit changes pandas version to 2.0.3 to solve Github Actions incompatibilities with its jobs. It also adds egcenv/ to .gitignore